### PR TITLE
Add Strapi token header support

### DIFF
--- a/.env.server
+++ b/.env.server
@@ -2,3 +2,5 @@ NEXT_PUBLIC_UI_DIALOG_AVATAR='false'
 NEXT_PUBLIC_URL='https://v2.pinst.co.id'
 NEXT_PUBLIC_STRAPI_URL='https://cms.pinst.co.id'
 NEXT_PUBLIC_STRAPI_API='https://cms.pinst.co.id/api'
+# Bearer token for authenticated requests to Strapi API
+STRAPI_API_TOKEN=

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ You can start editing the page by modifying `app/page.js`. The page auto-updates
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
 
+## Environment Variables
+
+Create a `.env.server` (or `.env.local`) file and provide the following values:
+
+```bash
+NEXT_PUBLIC_UI_DIALOG_AVATAR='false'
+NEXT_PUBLIC_URL='https://v2.pinst.co.id'
+NEXT_PUBLIC_STRAPI_URL='https://cms.pinst.co.id'
+NEXT_PUBLIC_STRAPI_API='https://cms.pinst.co.id/api'
+STRAPI_API_TOKEN=<your_strapi_api_token>
+```
+
+`STRAPI_API_TOKEN` should be a read-only API token generated from Strapi so API requests can be authenticated.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/src/app/api/apiService.js
+++ b/src/app/api/apiService.js
@@ -6,8 +6,11 @@ export const fetchData = async (slug, params = {}) => {
     const queryString = QueryString.stringify(params, {
       encodeValuesOnly: true,
     });
+    const token = process.env.STRAPI_API_TOKEN;
+    const headers = token ? { Authorization: `Bearer ${token}` } : {};
     const response = await axios.get(
-      `${process.env.NEXT_PUBLIC_STRAPI_API}/${slug}?${queryString}`
+      `${process.env.NEXT_PUBLIC_STRAPI_API}/${slug}?${queryString}`,
+      { headers }
     );
     return response.data;
   } catch (error) {


### PR DESCRIPTION
## Summary
- inject `STRAPI_API_TOKEN` header into API requests
- document new environment variable for deployments

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68815c93fb008320b9883d156e120c59